### PR TITLE
Add Updating of Tasks

### DIFF
--- a/src/main/java/duke/command/DeadlineCommand.java
+++ b/src/main/java/duke/command/DeadlineCommand.java
@@ -41,7 +41,7 @@ public class DeadlineCommand extends Command implements TaskListAddable {
         if (eventList.length != 2) {
             throw new DukeException("Incorrect command was given for deadline. "
                     + "Try this: deadline name_here"
-                    + " /at date_here");
+                    + " /by date_here");
         }
         Task event = new Deadline(eventList[0], eventList[1], false);
         String feedback = addTaskToTaskList(taskList, event);

--- a/src/main/java/duke/command/UpdateCommand.java
+++ b/src/main/java/duke/command/UpdateCommand.java
@@ -1,0 +1,125 @@
+package duke.command;
+
+import duke.commandresult.CommandResult;
+import duke.exception.DukeException;
+import duke.task.Task;
+import duke.task.TaskType;
+import duke.tasklist.TaskList;
+
+public class UpdateCommand extends Command {
+
+    public static final String COMMAND_WORD = "update";
+
+    private final String restOfWords;
+
+    private int id;
+
+    private String updatedName;
+
+    private String updatedDate;
+
+    /**
+     * Abstract constructor that will have to be implemented by all classes that extend Command.
+     *
+     * @param taskList that is passed by Duke.
+     */
+    public UpdateCommand(TaskList taskList, String rest) {
+        super(taskList);
+        this.restOfWords = rest;
+    }
+
+    public void setUpdatedName(String updatedName) {
+        this.updatedName = updatedName;
+    }
+
+    public void setUpdatedDate(String updatedDate) {
+        this.updatedDate = updatedDate;
+    }
+
+    @Override
+    public CommandResult execute() throws DukeException {
+        parseThroughRest();
+        Task task = this.getTaskList().get(this.id);
+        String feedback = "I've updated this task in your list from\n";
+        if (task.getTaskType().equals(TaskType.T)) {
+            if (!checkIfUpdatedDateIsNull()) {
+                throw new DukeException("This task is a Todo task, and can only accept a change in name.");
+            }
+            if (checkIfUpdatedNameIsNull()) {
+                throw new DukeException("This task is a Todo task, and no updated name was supplied.");
+            }
+            Task updatedTask = task.updateName(this.updatedName);
+            Task oldTask = this.getTaskList().updateTask(updatedTask, this.id);
+            feedback = feedback + "\n" + oldTask.toString() + "\n to" + "\n" + updatedTask.toString();
+            return new CommandResult(feedback, false);
+        }
+        if (checkIfUpdatedNameIsNull() && checkIfUpdatedDateIsNull()) {
+            throw new DukeException("This is a Timed Task. You have to supply either an updated name OR a date.");
+        }
+        Task updatedTask = updateNameOfTask(task);
+        Task updatedTask1 = updateDateOfTask(updatedTask);
+        Task oldTask = this.getTaskList().updateTask(updatedTask1, this.id);
+        feedback = feedback + "\n" + oldTask.toString() + "\n to" + "\n" + updatedTask1.toString();
+        return new CommandResult(feedback, false);
+    }
+
+    private boolean checkIfUpdatedNameIsNull() {
+        return this.updatedName == null;
+    }
+
+    private boolean checkIfUpdatedDateIsNull() {
+        return this.updatedDate == null;
+    }
+
+    private Task updateNameOfTask(Task task) throws DukeException {
+        if (checkIfUpdatedNameIsNull()) {
+            return task;
+        }
+        return task.updateName(this.updatedName);
+    }
+
+    private Task updateDateOfTask(Task task) throws DukeException {
+        if (checkIfUpdatedDateIsNull()) {
+            return task;
+        }
+        return task.updateDateTime(this.updatedDate);
+    }
+
+    private void parseThroughRest() throws DukeException {
+        String[] split = this.restOfWords.split("(?=/)");
+        lookForAndSetId(split);
+        lookForAndSetName(split);
+        lookForAndSetDateTime(split);
+    }
+
+    private void lookForAndSetId(String[] splitString) throws DukeException {
+        for (String s: splitString) {
+            System.out.println(s);
+            if (s.startsWith("/i")) {
+                String res = s.substring(2);
+                this.id = Integer.parseInt(res.trim());
+                return;
+            }
+        }
+        throw new DukeException(
+                "Id was not passed when updating. Please try this format\n"
+                        + "update /i (the id of the task to update) /n (the new name of the task) /d (the new date of the task)"
+        );
+    }
+
+    private void lookForAndSetName(String[] splitString) {
+        for (String s: splitString) {
+            if (s.startsWith("/n")) {
+                setUpdatedName(s.substring(2).trim());
+            }
+        }
+    }
+
+    private void lookForAndSetDateTime(String[] splitString) {
+        for (String s: splitString) {
+            if (s.startsWith("/d")) {
+                setUpdatedDate(s.substring(2).trim());
+            }
+        }
+    }
+}

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -9,6 +9,7 @@ import duke.command.ExitCommand;
 import duke.command.FindCommand;
 import duke.command.ListCommand;
 import duke.command.TodoCommand;
+import duke.command.UpdateCommand;
 import duke.exception.DukeException;
 import duke.tasklist.TaskList;
 
@@ -65,6 +66,9 @@ public class Parser {
                     throw new DukeException("You can only include 1 search word.");
                 }
                 return new FindCommand(taskList, words[1]);
+            case UpdateCommand.COMMAND_WORD:
+                rest = combine(words, words.length);
+                return new UpdateCommand(taskList, rest);
             case ExitCommand.COMMAND_WORD:
                 return new ExitCommand(taskList);
             default:

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -24,13 +24,13 @@ public class Deadline extends TimedTask {
     }
 
     @Override
-    public Task updateName(String input) {
-        try {
-            return new Deadline(input, this.getDateTimeInternal(), this.getCompleted());
-        } catch (DukeException e) {
-            System.out.println(e.getMessage());
-            return Task.emptyTask();
-        }
+    public Task updateDateTime(String dateTime) throws DukeException{
+        return new Deadline(this.getName(), dateTime, this.getCompleted());
+    }
+
+    @Override
+    public Task updateName(String input) throws DukeException {
+        return new Deadline(input, this.getDateTimeInternal(), this.getCompleted());
     }
 
     @Override

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -24,13 +24,13 @@ public class Event extends TimedTask {
     }
 
     @Override
-    public Task updateName(String input) {
-        try {
-            return new Deadline(input, this.getDateTimeInternal(), this.getCompleted());
-        } catch (DukeException e) {
-            System.out.println(e.getMessage());
-            return Task.emptyTask();
-        }
+    public Task updateDateTime(String dateTime) throws DukeException {
+        return new Event(this.getName(), dateTime, this.getCompleted());
+    }
+
+    @Override
+    public Task updateName(String input) throws DukeException{
+        return new Event(input, this.getDateTimeInternal(), this.getCompleted());
     }
 
     @Override

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -1,5 +1,7 @@
 package duke.task;
 
+import duke.exception.DukeException;
+
 public abstract class Task {
     public static final EmptyTask EMPTY_TASK = EmptyTask.empty();
     private final String name;
@@ -24,7 +26,9 @@ public abstract class Task {
         return this.isCompleted;
     }
 
-    public abstract Task updateName(String input);
+    public abstract Task updateName(String input) throws DukeException;
+
+    public abstract Task updateDateTime(String dateTime) throws DukeException;
 
     public abstract Task complete();
 
@@ -57,6 +61,11 @@ public abstract class Task {
 
         @Override
         public EmptyTask updateName(String input) {
+            return this;
+        }
+
+        @Override
+        public Task updateDateTime(String dateTime) {
             return this;
         }
 

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -20,6 +20,11 @@ public class Todo extends Task {
     }
 
     @Override
+    public Task updateDateTime(String dateTime) {
+        return new Todo(this.getName(), this.getCompleted());
+    }
+
+    @Override
     public Task complete() {
         return new Todo(this.getName(), true);
     }

--- a/src/main/java/duke/tasklist/TaskList.java
+++ b/src/main/java/duke/tasklist/TaskList.java
@@ -65,6 +65,17 @@ public class TaskList {
         }
     }
 
+    public Task updateTask(Task task, int taskId) throws DukeException {
+        Task taskRetrieved;
+        try {
+            taskRetrieved = tasks.get(taskId - 1);
+            tasks.set(taskId - 1, task);
+            return taskRetrieved;
+        } catch (java.lang.IndexOutOfBoundsException e) {
+            throw new DukeException("That task does not exist.");
+        }
+    }
+
     /**
      * Marks and returns a completed task.
      * @param taskId of the task that is to be completed.

--- a/src/test/java/duke/ParserTest.java
+++ b/src/test/java/duke/ParserTest.java
@@ -30,4 +30,34 @@ public class ParserTest {
         Task task = taskList.get(1);
         assertEquals(task.toString(), "[T][ ] finish ip");
     }
+
+    @Test
+    public void parseAndUpdate() throws DukeException {
+        Storage storage = Storage.createStorage("data/test.txt");
+        TaskList taskList = new TaskList();
+        storage.load(taskList);
+        Command command = new Parser(taskList).parse("todo finish ip");
+        command.execute();
+        Task task = taskList.get(1);
+        assertEquals("[T][ ] finish ip", task.toString());
+        Command command1 = new Parser(taskList).parse("update /i 1 /n finish");
+        command1.execute();
+        Task task1 = taskList.get(1);
+        assertEquals("[T][ ] finish", task1.toString());
+    }
+
+    @Test
+    public void parseAndUpdateDeadline() throws DukeException {
+        Storage storage = Storage.createStorage("data/test.txt");
+        TaskList taskList = new TaskList();
+        storage.load(taskList);
+        Command command = new Parser(taskList).parse("deadline finish ip /by 2021-10-10 10:00");
+        command.execute();
+        Task task = taskList.get(1);
+        assertEquals("[D][ ] finish ip (by: Oct 10 2021 10:00:00)", task.toString());
+        Command command1 = new Parser(taskList).parse("update /i 1 /n finish hw /d 2021-10-10 11:00");
+        command1.execute();
+        Task task1 = taskList.get(1);
+        assertEquals("[D][ ] finish hw (by: Oct 10 2021 11:00:00)", task1.toString());
+    }
 }


### PR DESCRIPTION
Adding class to support extension of IP: Update Tasks.

Previously, updating tasks would require the deletion and re-addition of tasks. A new UpdateCommand class should be created to support the new requirement.

Creating and adding a field to the parser will allow for easy updates of Tasks without having to change anything else. This completes the CRUD functionality.

As a step towards this feature, let's create a new Command, UpdateCommand, and add a case to be handled by the parser.